### PR TITLE
PLANET: Match font styling with main page

### DIFF
--- a/scummvm_template/index.html.tmpl
+++ b/scummvm_template/index.html.tmpl
@@ -71,7 +71,7 @@
 </ul>
 	</div> </div> 
 <div><img src="./images/hangmonk.gif" alt="monkey" width="55" height="57" class="monkey float_right" /></div> 
-	<div id="menu_banners"> 
+	<div id="menu_banners" style="font-size: 10px;"> 
 <strong>Last updated:</strong><br>
 <TMPL_VAR date><br>
 <em>All times are UTC.</em><br>

--- a/scummvm_template/layout.css
+++ b/scummvm_template/layout.css
@@ -18,7 +18,7 @@ color: #000000;
 
 td, th
 {
-font-size: 10px; 
+font-size: 9pt; 
 color: #000000;
 }
 
@@ -477,17 +477,17 @@ h3 a:link, h3 a:visited, h3 a:hover {
 h4 a:link, h4 a:visited, h4 a:hover { 
 	font-size: 150%;
 } 
-h1 { font-size: 188%; }
+h1 { font-size: 150%; }
 h1 .editsection { font-size: 53%; }
-h2 { font-size: 150%; }
+h2 { font-size: 125%; }
 h2 .editsection { font-size: 67%; }
 h3, h4, h5, h6 {
 	font-weight: bold;
 	color: black;
 }
-h3 { font-size: 132%; }
+h3 { font-size: 110%; }
 h3 .editsection { font-size: 76%; font-weight: normal; }
-h4 { font-size: 116%; }
+h4 { font-size: 100%; }
 h4 .editsection { font-size: 86%; font-weight: normal; }
 h5 { font-size: 100%; }
 h5 .editsection { font-weight: normal; }

--- a/scummvm_template/menu.css
+++ b/scummvm_template/menu.css
@@ -11,7 +11,7 @@
 
 div.menugroup {
 	background: transparent url('./images/menu-bottom.png') scroll no-repeat bottom left;
-	/*font-size: 9pt;*/
+	font-size: 9pt;
 	margin-bottom: 8px;
 	overflow: hidden;
 	padding-bottom: 12px;

--- a/scummvm_template/planet.css
+++ b/scummvm_template/planet.css
@@ -5,18 +5,17 @@ img.face {
 
 .entry {
 	margin-bottom: 2em;
-	font-family: "Bitstream Vera Sans", sans-serif;
+	font: normal 9pt/normal verdana, tahoma, arial, helvetica, sans-serif;
 	padding-top: 5px;
 	padding-left: 5px;
 	padding-right: 5px;
 	padding-bottom: 5px;
 	background-color: #f6e08b;
 	border: 1px solid #000000;
-	/* font-size: 75%; */
 }
 
 .entry .date {
-	font-family: "Bitstream Vera Sans", sans-serif;
+	font-family: verdana, tahoma, arial, helvetica, sans-serif;
 	color: grey;
 }
 


### PR DESCRIPTION
Currently, the ScummVM planet uses a font size of 8px, which is way to small in my opinion.

With this PR, I try to match the font styling with the one of the "new" ScummVM main page. Please notice that I am not a CSS expert, so things might be wrong. I couldn't find any obvious styling errors, but feel free to correct me. The only thing I can't get to work is the max width of 1500px as on the main page.
