### PR TITLE
BUILDBOT: Re-enable the event recorder on native builds

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -1573,18 +1573,11 @@ for name, config in scumm_platforms_master.items():
 	if scumm_verbose_build_master:
 		platform_build_verbosity = "--enable-verbose-build"
 
-	# 20130706 Tests currently break if event recorder is enabled, so disable
-	# for the native (tests) build. Remove when this is fixed.
-	platform_disable_eventrecorder = ""
-	if name in scumm_native_buildname:
-		platform_disable_eventrecorder = "--disable-eventrecorder"
-
 	f.addStep(scumm.Configure(command = [
 											configure_path,
 											"--enable-all-engines",
 											"--disable-engine=testbed",
-											platform_build_verbosity,
-											platform_disable_eventrecorder
+											platform_build_verbosity
 										] + config["configureargs"],
 								env = config["env"]))
 
@@ -1634,16 +1627,9 @@ for name, config in scumm_platforms_stable.items():
 	if scumm_verbose_build_stable:
 		platform_build_verbosity = "--enable-verbose-build"
 
-	# 20130706 Tests currently break if event recorder is enabled, so disable
-	# for the native (tests) build. Remove when this is fixed.
-	platform_disable_eventrecorder = ""
-	if name in scumm_native_buildname:
-		platform_disable_eventrecorder = "--disable-eventrecorder"
-
 	f.addStep(scumm.Configure(command = [
 											configure_path,
-											platform_build_verbosity,
-											platform_disable_eventrecorder
+											platform_build_verbosity
 										] + config["configureargs"],
 								env = config["env"]))
 
@@ -1752,18 +1738,11 @@ for name, config in scumm_platforms_other.items():
 	if scumm_other_verbose_build:
 		platform_build_verbosity = "--enable-verbose-build"
 
-	# 20130706 Tests currently break if event recorder is enabled, so disable
-	# for the native (tests) build. Remove when this is fixed.
-	platform_disable_eventrecorder = ""
-	if name in scumm_native_buildname:
-		platform_disable_eventrecorder = "--disable-eventrecorder"
-
 	f.addStep(scumm.Configure(command = [
 											configure_path,
 											"--enable-all-engines",
 											"--disable-engine=testbed",
-											platform_build_verbosity,
-											platform_disable_eventrecorder
+											platform_build_verbosity
 										] + config["configureargs"],
 								env = config["env"]))
 


### PR DESCRIPTION
Building the tests with the event recorder is now fixed

This is untested
