### PR TITLE
BUILDBOT: Disable testing of untestable platforms

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -142,6 +142,9 @@ scumm_desktop_platforms = []
 # These platforms are defined as "Build Only" and thus will not be packaged for download.
 scumm_buildonly_platforms = []
 
+# These platforms are defined as "unable to run tests" and thus will not build or run tests
+scumm_untestable_platforms = []
+
 # Native build (for triggering tests - Can't run cross compiled binaries, so can only run test on native)
 scumm_native_buildname = "debian-x86_64"
 
@@ -736,6 +739,7 @@ p = {
 
 scumm_platforms_master["ps2"] = p
 scumm_platforms_stable["ps2"] = p
+scumm_untestable_platforms.append("ps2")
 
 # GP2X
 scumm_root_gp2x = "/opt/toolchains/open2x-gcc-4.1.1"
@@ -1589,7 +1593,7 @@ for name, config in scumm_platforms_master.items():
 
 	if name in scumm_native_buildname:
 		f.addStep(Test(env = config["env"]))
-	else:
+	elif name not in scumm_untestable_platforms:
 		# Compile Tests (Runner), but do not execute (as binary is non-native)
 		f.addStep(Test(command = [ "make", "test/runner" ], env = config["env"]))
 


### PR DESCRIPTION
PS2 compiler is too old to build the test runner, so disable it in a
generic manner similar to `scumm_buildonly_platforms`.