### PR TITLE
BUILDBOT: Try to optimize nightly builds

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -12,6 +12,7 @@ sys.path.append(expanded_base_dir)
 
 import scumm
 import scummsecret
+from buildbot.process.properties import Interpolate
 
 buildbot_www = "/var/www/buildbot"
 
@@ -1498,7 +1499,7 @@ if scumm_build_nightly_master:
 	f.addStep(Trigger(schedulerNames = [ "master" ],
 						updateSourceStamp = True,
 						waitForFinish = True,
-						set_properties = { "package": True }))
+						set_properties = { "package": True, "optimizations_flag": "--enable-optimizations" }))
 
 	c["builders"].append( {
 		"name": "nightly-master",
@@ -1577,6 +1578,7 @@ for name, config in scumm_platforms_master.items():
 											configure_path,
 											"--enable-all-engines",
 											"--disable-engine=testbed",
+											Interpolate("%(prop:optimizations_flag)s"),
 											platform_build_verbosity
 										] + config["configureargs"],
 								env = config["env"]))


### PR DESCRIPTION
`buildbot checkconfig` seems to think this new configuration is OK, but I don't actually know if this will work or not since I do not have a readily-available buildbot setup to test it. Another option would be to just turn on optimizations for everything, which might be better for ccache but would slow down all the incremental builds, though this could be mitigated by using -Og in GCC 4.8+. Another other option would be to enable optimized builds just for the popular platforms (Windows/Linux/macOS/Android? Just Windows?) since that seems to be the platform in most critical need of these updates.

Refs Trac#10248.