### PR TITLE
BUILDBOT: Define PKG_CONFIG_PATH for the toolchains that have .pc files

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -157,6 +157,7 @@ scumm_env_debian_x86["CPPFLAGS"] = "-isystem %s/usr/include" % scumm_root_debian
 scumm_env_debian_x86["CXXFLAGS"] = "-m32"
 scumm_env_debian_x86["LDFLAGS"] = "-m32 -Wl,-rpath,%s/lib/i386-linux-gnu -Wl,-rpath,%s/usr/lib/i386-linux-gnu -L%s/usr/lib/i386-linux-gnu" % \
                                   (scumm_root_debian_x86, scumm_root_debian_x86, scumm_root_debian_x86)
+scumm_env_debian_x86["PKG_CONFIG_LIBDIR"] = "%s/usr/lib/i386-linux-gnu/pkgconfig" % scumm_root_debian_x86
 
 p = {
 	"configureargs": [
@@ -250,6 +251,7 @@ scumm_env_debian_x86_clang["CPPFLAGS"] = "-isystem %s/usr/include" % scumm_root_
 scumm_env_debian_x86_clang["CXXFLAGS"] = "-m32 -Qunused-arguments"
 scumm_env_debian_x86_clang["LDFLAGS"] = "-m32 -Wl,-rpath,%s/lib/i386-linux-gnu -Wl,-rpath,%s/usr/lib/i386-linux-gnu -L%s/usr/lib/i386-linux-gnu" % \
                                   (scumm_root_debian_x86_clang, scumm_root_debian_x86_clang, scumm_root_debian_x86_clang)
+scumm_env_debian_x86_clang["PKG_CONFIG_LIBDIR"] = "%s/usr/lib/i386-linux-gnu/pkgconfig" % scumm_root_debian_x86_clang
 
 p = {
 	"configureargs": [
@@ -290,6 +292,7 @@ scumm_env_mingw_w32["PATH"] = "%s/bin:%s" % (scumm_root_mingw_w32, DEFAULT_PATH)
 scumm_env_mingw_w32["CXX"] = "ccache i686-w64-mingw32-g++"
 scumm_env_mingw_w32["CXXFLAGS"] = "-isystem %s/include" % scumm_root_mingw_w32
 scumm_env_mingw_w32["LDFLAGS"] = "-L%s/lib" % scumm_root_mingw_w32
+scumm_env_mingw_w32["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_mingw_w32
 
 p = {
 	"configureargs": [
@@ -333,6 +336,7 @@ scumm_env_mingw_w64["PATH"] = "%s/bin:%s" % (scumm_root_mingw_w64, DEFAULT_PATH)
 scumm_env_mingw_w64["CXX"] = "ccache x86_64-w64-mingw32-g++"
 scumm_env_mingw_w64["CXXFLAGS"] = "-isystem %s/include" % scumm_root_mingw_w64
 scumm_env_mingw_w64["LDFLAGS"] = "-L%s/lib" % scumm_root_mingw_w64
+scumm_env_mingw_w64["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_mingw_w64
 
 p = {
 	"configureargs": [
@@ -386,6 +390,7 @@ scumm_env_wii["PATH"] = "%s/devkitPPC/bin:%s" % (scumm_root_wii, DEFAULT_PATH)
 scumm_env_wii["CXX"] = "ccache powerpc-eabi-g++"
 scumm_env_wii["CXXFLAGS"] = "-isystem %s/3rd/include" % scumm_root_wii
 scumm_env_wii["LDFLAGS"] = "-L%s/3rd/lib" % scumm_root_wii
+scumm_env_wii["PKG_CONFIG_LIBDIR"] = "%s/3rd/lib/pkgconfig" % scumm_root_wii
 scumm_env_wii["DEVKITPRO"] = "%s" % scumm_root_wii
 scumm_env_wii["DEVKITPPC"] = "%s/devkitPPC" % scumm_root_wii
 
@@ -412,6 +417,7 @@ scumm_env_gc["PATH"] = "%s/devkitPPC/bin:%s" % (scumm_root_gc, DEFAULT_PATH)
 scumm_env_gc["CXX"] = "ccache powerpc-eabi-g++"
 scumm_env_gc["CXXFLAGS"] = "-isystem %s/3rd/include" % scumm_root_gc
 scumm_env_gc["LDFLAGS"] = "-L%s/3rd/lib" % scumm_root_gc
+scumm_env_gc["PKG_CONFIG_LIBDIR"] = "%s/3rd/lib/pkgconfig" % scumm_root_gc
 scumm_env_gc["DEVKITPRO"] = "%s" % scumm_root_gc
 scumm_env_gc["DEVKITPPC"] = "%s/devkitPPC" % scumm_root_gc
 
@@ -490,6 +496,7 @@ scumm_env_osx_intel["PATH"] = "%s/bin:%s" % (scumm_root_osx_intel, DEFAULT_PATH)
 scumm_env_osx_intel["CXX"] = "ccache i686-apple-darwin9-g++"
 scumm_env_osx_intel["CXXFLAGS"] = "-I %s/include -I %s/SDKs/MacOSX10.4u.sdk/usr/include/c++/4.0.0/ -I %s/SDKs/MacOSX10.4u.sdk/usr/include/c++/4.0.0/i686-apple-darwin9" % (scumm_root_osx_intel,scumm_root_osx_intel,scumm_root_osx_intel)
 scumm_env_osx_intel["LDFLAGS"] = "-L%s/lib" % scumm_root_osx_intel
+scumm_env_osx_intel["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_osx_intel
 
 p = {
 	"configureargs": [
@@ -539,6 +546,7 @@ scumm_desktop_platforms.append("osx_intel")
 #scumm_env_osx_ppc["CXX"] = "ccache ppc-apple-darwin8-g++"
 #scumm_env_osx_ppc["CXXFLAGS"] = "-fabi-version=1 -fno-use-cxa-atexit -I %s/include" % scumm_root_osx_ppc
 #scumm_env_osx_ppc["LDFLAGS"] = "-L%s/lib -static-libgcc -ldl" % scumm_root_osx_ppc
+#scumm_env_osx_ppc["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_osx_ppc
 #scumm_env_osx_ppc["MACOSX_DEPLOYMENT_TARGET"] = "10.2"
 #
 #scumm_tools_env_osx_ppc = copy.deepcopy(scumm_env_osx_ppc)
@@ -594,6 +602,7 @@ scumm_env_ios["CXX"] = "ccache arm-apple-darwin9-clang++"
 scumm_env_ios["CPPFLAGS"] = "-isystem %s/include" % scumm_root_ios_libs
 scumm_env_ios["CXXFLAGS"] = "-Qunused-arguments"
 scumm_env_ios["LDFLAGS"] = "-L%s/lib" % scumm_root_ios_libs
+scumm_env_ios["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_ios_libs
 
 p = {
 	"configureargs": [
@@ -624,6 +633,7 @@ scumm_env_ios7["CXX"] = "ccache arm-apple-darwin11-clang++"
 scumm_env_ios7["CPPFLAGS"] = "-isystem %s/include" % scumm_root_ios7_libs
 scumm_env_ios7["CXXFLAGS"] = "-Qunused-arguments"
 scumm_env_ios7["LDFLAGS"] = "-L%s/lib" % scumm_root_ios7_libs
+scumm_env_ios7["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_ios7_libs
 
 p = {
 	"configureargs": [
@@ -714,6 +724,7 @@ scumm_platforms_stable["psp"] = p_stable
 scumm_root_psp2 = "/opt/toolchains/psp2"
 scumm_env_psp2 = copy.deepcopy(scumm_env)
 scumm_env_psp2["PATH"] = "%s/vitasdk/bin:%s" % (scumm_root_psp2, DEFAULT_PATH)
+scumm_env_psp2["PKG_CONFIG_LIBDIR"] = "%s/vitasdk/arm-vita-eabi/lib/pkgconfig" % scumm_root_psp2
 scumm_env_psp2["VITASDK"] = "%s/vitasdk" % (scumm_root_psp2)
 
 # HACK: disable the unstable engines to prevent memory-related crash on startup
@@ -773,6 +784,7 @@ scumm_env_gp2x["PATH"] = "%s/bin:%s" % (scumm_root_gp2x, DEFAULT_PATH)
 scumm_env_gp2x["CXX"] = "ccache arm-open2x-linux-g++"
 scumm_env_gp2x["CXXFLAGS"] = "-isystem %s/include" % scumm_root_gp2x
 scumm_env_gp2x["LDFLAGS"] = "-L%s/lib" % scumm_root_gp2x
+scumm_env_gp2x["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_gp2x
 
 p_master = {
 	"configureargs": [
@@ -805,6 +817,7 @@ scumm_env_gp2xwiz["PATH"] = "%s/bin:%s" % (scumm_root_gp2xwiz, DEFAULT_PATH)
 scumm_env_gp2xwiz["CXX"] = "ccache arm-open2x-linux-g++"
 scumm_env_gp2xwiz["CXXFLAGS"] = "-isystem %s/include" % scumm_root_gp2xwiz
 scumm_env_gp2xwiz["LDFLAGS"] = "-L%s/lib" % scumm_root_gp2xwiz
+scumm_env_gp2xwiz["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_gp2xwiz
 
 p_master = {
 	"configureargs": [
@@ -927,6 +940,7 @@ scumm_env_motoezx["PATH"] = "%s/bin:%s/crosstool/bin:%s" % (scumm_root_motoezx, 
 scumm_env_motoezx["CXX"] = "ccache arm-linux-gnu-g++"
 scumm_env_motoezx["CXXFLAGS"] = "-isystem %s/include" % (scumm_root_motoezx)
 scumm_env_motoezx["LDFLAGS"] = "-L%s/lib" % scumm_root_motoezx
+scumm_env_motoezx["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_motoezx
 
 p = {
 	"configureargs": [
@@ -949,6 +963,7 @@ scumm_env_motomagx["PATH"] = "%s/bin:%s" % (scumm_root_motomagx, DEFAULT_PATH)
 scumm_env_motomagx["CXX"] = "ccache arm-linux-gnueabi-g++"
 scumm_env_motomagx["CXXFLAGS"] = "-isystem %s/include" % (scumm_root_motomagx)
 scumm_env_motomagx["LDFLAGS"] = "-L%s/lib" % scumm_root_motomagx
+scumm_env_motomagx["PKG_CONFIG_LIBDIR"] = "%s/lib/pkgconfig" % scumm_root_motomagx
 
 p = {
 	"configureargs": [
@@ -996,6 +1011,7 @@ scumm_root_dingux = "/opt/toolchains/dingux-mipsel"
 scumm_env_dingux = copy.deepcopy(scumm_env)
 scumm_env_dingux["PATH"] = "%s/usr/bin:%s" % (scumm_root_dingux, DEFAULT_PATH)
 scumm_env_dingux["CXX"] = "ccache mipsel-linux-g++"
+scumm_env_dingux["PKG_CONFIG_LIBDIR"] = "%s/usr/lib/pkgconfig" % scumm_root_dingux
 # HACK: The toolchain was built using libraries not available in recent Debian
 # releases. We keep a copy of the old libraries around and use LD_LIBRARY_PATH
 # to have ld.so find them.
@@ -1025,6 +1041,7 @@ scumm_root_openpandora = "/opt/toolchains/arm-angstrom-openpandora"
 scumm_env_openpandora = copy.deepcopy(scumm_env)
 scumm_env_openpandora["PATH"] = "%s/bin:%s" % (scumm_root_openpandora, DEFAULT_PATH)
 scumm_env_openpandora["CXX"] = "ccache arm-angstrom-linux-gnueabi-g++"
+scumm_env_openpandora["PKG_CONFIG_LIBDIR"] = "%s/arm-angstrom-linux-gnueabi/usr/lib/pkgconfig" % scumm_root_openpandora
 # HACK: The toolchain was built using libraries not available in recent Debian
 # releases. We keep a copy of the old libraries around and use LD_LIBRARY_PATH
 # to have ld.so find them.
@@ -1058,6 +1075,7 @@ scumm_env_caanoo["PATH"] = "%s/bin:%s" % (scumm_root_caanoo, DEFAULT_PATH)
 scumm_env_caanoo["CXX"] = "ccache arm-none-linux-gnueabi-g++"
 scumm_env_caanoo["CXXFLAGS"] = "-isystem %s/arm-none-linux-gnueabi/usr/include" % scumm_root_caanoo
 scumm_env_caanoo["LDFLAGS"] = "-L%s/arm-none-linux-gnueabi/usr/lib" % scumm_root_caanoo
+scumm_env_caanoo["PKG_CONFIG_LIBDIR"] = "%s/arm-none-linux-gnueabi/usr/lib/pkgconfig" % scumm_root_caanoo
 
 p_master = {
 	"configureargs": [
@@ -1092,6 +1110,7 @@ scumm_root_gcw0 = "/opt/gcw0-toolchain"
 scumm_env_gcw0 = copy.deepcopy(scumm_env)
 scumm_env_gcw0["PATH"] = "%s/usr/bin:%s" % (scumm_root_gcw0, DEFAULT_PATH)
 scumm_env_gcw0["CXX"] = "ccache mipsel-linux-g++"
+scumm_env_gcw0["PKG_CONFIG_LIBDIR"] = "%s/usr/mipsel-gcw0-linux-uclibc/sysroot/usr/lib/pkgconfig" % scumm_root_gcw0
 
 p = {
 	"configureargs": [
@@ -1122,6 +1141,7 @@ scumm_env_android_arm["PATH"] = "%s/toolchains/arm-linux-androideabi-4.6/prebuil
 scumm_env_android_arm["CXX"] = "ccache arm-linux-androideabi-g++"
 scumm_env_android_arm["CXXFLAGS"] = "-isystem %s/3rd-android-4-armeabi-debug/include" % scumm_root_android
 scumm_env_android_arm["LDFLAGS"] = "-L%s/3rd-android-4-armeabi-debug/lib" % scumm_root_android
+scumm_env_android_arm["PKG_CONFIG_LIBDIR"] = "%s/3rd-android-4-armeabi-debug/lib/pkgconfig" % scumm_root_android
 
 p = {
 	"configureargs": [
@@ -1143,6 +1163,7 @@ scumm_env_android_mips["PATH"] = "%s/toolchains/mipsel-linux-android-4.6/prebuil
 scumm_env_android_mips["CXX"] = "ccache mipsel-linux-android-g++"
 scumm_env_android_mips["CXXFLAGS"] = "-isystem %s/3rd-android-9-mipsel-debug/include" % scumm_root_android
 scumm_env_android_mips["LDFLAGS"] = "-L%s/3rd-android-9-mipsel-debug/lib" % scumm_root_android
+scumm_env_android_mips["PKG_CONFIG_LIBDIR"] = "%s/3rd-android-9-mipsel-debug/lib/pkgconfig" % scumm_root_android
 
 p = {
 	"configureargs": [
@@ -1164,6 +1185,7 @@ scumm_env_android_x86["PATH"] = "%s/toolchains/x86-4.6/prebuilt/linux-x86/bin:%s
 scumm_env_android_x86["CXX"] = "ccache i686-linux-android-g++"
 scumm_env_android_x86["CXXFLAGS"] = "-isystem %s/3rd-android-9-x86-debug/include" % scumm_root_android
 scumm_env_android_x86["LDFLAGS"] = "-L%s/3rd-android-9-x86-debug/lib" % scumm_root_android
+scumm_env_android_x86["PKG_CONFIG_LIBDIR"] = "%s/3rd-android-9-x86-debug/lib/pkgconfig" % scumm_root_android
 
 p = {
 	"configureargs": [
@@ -1183,6 +1205,7 @@ scumm_platforms_stable["android_x86"] = p
 scumm_env_ouya = copy.deepcopy(scumm_env_android_arm)
 scumm_env_ouya["CXXFLAGS"] = "-isystem %s/3rd-android-4-armeabi-v7a-debug/include" % scumm_root_android
 scumm_env_ouya["LDFLAGS"] = "-L%s/3rd-android-4-armeabi-v7a-debug/lib" % scumm_root_android
+scumm_env_ouya["PKG_CONFIG_LIBDIR"] = "%s/3rd-android-4-armeabi-v7a-debug/lib/pkgconfig" % scumm_root_android
 
 p = {
 	"configureargs": [
@@ -1203,6 +1226,7 @@ scumm_root_webos = "/opt/toolchains/webos"
 scumm_env_webos = copy.deepcopy(scumm_env)
 scumm_env_webos["PATH"] = "%s/PalmPDK/arm-gcc/bin:%s/PalmPDK/bin:%s" % (scumm_root_webos, scumm_root_webos, DEFAULT_PATH)
 scumm_env_webos["CXX"] = "ccache arm-none-linux-gnueabi-g++"
+scumm_env_webos["PKG_CONFIG_LIBDIR"] = "%s/PalmPDK/device/usr/lib/pkgconfig" % scumm_root_webos
 scumm_env_webos["WEBOS_SDK"] = "%s/PalmSDK/Current" % scumm_root_webos
 scumm_env_webos["WEBOS_PDK"] = "%s/PalmPDK" % scumm_root_webos
 
@@ -1226,6 +1250,7 @@ scumm_root_ps3 = "/opt/toolchains/ps3"
 scumm_env_ps3 = copy.deepcopy(scumm_env)
 scumm_env_ps3["PATH"] = "%s/bin:%s/ppu/bin:%s/spu/bin:%s" % (scumm_root_ps3, scumm_root_ps3, scumm_root_ps3, DEFAULT_PATH)
 scumm_env_ps3["CXX"] = "ccache powerpc64-ps3-elf-g++"
+scumm_env_ps3["PKG_CONFIG_LIBDIR"] = "%s/portlibs/ppu/lib/pkgconfig" % scumm_root_ps3
 scumm_env_ps3["PS3DEV"] = scumm_root_ps3
 scumm_env_ps3["PSL1GHT"] = "%s/psl1ght" % scumm_root_ps3
 
@@ -1247,6 +1272,7 @@ scumm_root_amigaos4 = "/opt/toolchains/amigaos4"
 scumm_env_amigaos4 = copy.deepcopy(scumm_env)
 scumm_env_amigaos4["PATH"] = "%s/bin:%s/ppc-amigaos/SDK/local/newlib/bin:%s" % (scumm_root_amigaos4, scumm_root_amigaos4, DEFAULT_PATH)
 scumm_env_amigaos4["CXX"] = "ccache ppc-amigaos-g++"
+scumm_env_amigaos4["PKG_CONFIG_LIBDIR"] = "%s/ppc-amigaos/SDK/local/newlib/lib/pkgconfig" % scumm_root_amigaos4
 
 p_master = {
 	"configureargs": [


### PR DESCRIPTION
This is to be able to merge https://github.com/scummvm/scummvm/pull/1185, which uses `pkg-config` to detect FreeType.

There are still some problems with the toolchains that need to be solved before we can use `pkg-config` for FreeType:
- [ ] The Caanoo toolchain does not have a .pc file for FreeType (it has no .pc files at all)
- [ ] The motoezx toolchain does not have a .pc file for FreeType
- [ ] The WebOS toolchain does not have a .pc file for FreeType

I'll see if I can rebuild freetype for those toolchains. Or perhaps manually create .pc files from the output of `freetype-config` if that proves to be too difficult.

On the other hand, those platforms seem very unmaintained to me. Maybe they're not worth fixing. Toughts?