### PR TITLE
Hopefully fix the IRC notifications

### DIFF
--- a/config/scumm.py
+++ b/config/scumm.py
@@ -294,16 +294,16 @@ class IrcStatusBot(irc.IRCClient):
 
 	def buildStarted(self, builderName, build):
 		#builder = build.getBuilder()
-		#self.log('Builder %r in category %s started' % (builder, builder.category))
+		#self.log('Builder %r in category %s started' % (builder, builder.getCategory()))
 		return
 
 	def buildFinished(self, builderName, build, results):
 		builder = build.getBuilder()
 
 		# only notify about builders we are interested in
-		#self.log('Builder %r in category %s finished' % (builder, builder.category))
+		#self.log('Builder %r in category %s finished' % (builder, builder.getCategory()))
 
-		if (self.categories != None and builder.category not in self.categories):
+		if (self.categories != None and builder.getCategory() not in self.categories):
 			return
 
 		result = build.getResults()


### PR DESCRIPTION
I noticed this error in the buildbot server logs:
```
2018-07-28 05:32:43+0200 [-] Exception caught notifying <scumm.IrcStatusBot instance at 0x7f36af5bea28> of buildFinished event
2018-07-28 05:32:43+0200 [-] Unhandled Error
        Traceback (most recent call last):
          File "/usr/lib/python2.7/dist-packages/buildbot/status/build.py", line 320, in buildFinished
            w.callback(self)
          File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 457, in callback
            self._startRunCallbacks(result)
          File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 565, in _startRunCallbacks
            self._runCallbacks()
          File "/usr/lib/python2.7/dist-packages/twisted/internet/defer.py", line 651, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
        --- <exception caught here> ---
          File "/usr/lib/python2.7/dist-packages/buildbot/status/builder.py", line 597, in _buildFinished
            w.buildFinished(name, s, results)
          File "scumm.py", line 306, in buildFinished
            if (self.categories != None and builder.category not in self.categories):
        exceptions.AttributeError: BuilderStatus instance has no attribute 'category'
```

According to the documentation, `getCategory` should be used:
https://docs.buildbot.net/0.8.3/reference/buildbot.status.builder.BuilderStatus-class.html