### PR TITLE
BUILDBOT: Disable only lastexpress engine on PSP2 (Vita).

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -724,7 +724,7 @@ scumm_env_psp2["VITASDK"] = "%s/vitasdk" % (scumm_root_psp2)
 # file, which grows with number of engines, we need to disable some of the engines...
 p_master = {
 	"configureargs": [
-		"--disable-all-unstable-engines",
+		"--disable-engines=lastexpress",
 		"--host=psp2"
 	],
 	"env": scumm_env_psp2,


### PR DESCRIPTION
My own tests show that, at least for now, it is enough to only disable
lastexpress and keep the other unstable engines on Vita. This keeps the executable size small enough to prevent the size-related crash on startup. This might change again in the future.