### PR TITLE
BUILDBOT: Don't attempt to disable the myst3 and stark engines in stable builds

### DIFF
--- a/config/master.cfg
+++ b/config/master.cfg
@@ -889,19 +889,8 @@ scumm_env_psp2["PKG_CONFIG_LIBDIR"] = "%s/vitasdk/arm-vita-eabi/lib/pkgconfig" %
 scumm_env_psp2["CXX"] = "ccache arm-vita-eabi-g++"
 scumm_env_psp2["VITASDK"] = "%s/vitasdk" % (scumm_root_psp2)
 
-# HACK: To prevent memory-related crash on startup that seems related to the size of the executable
-# file, which grows with number of engines, we need to disable some of the engines...
-# Blade Runner is unplayably slow on the Vita.
-# Stark engine doesn't have a supported renderer on Vita.
-# Myst 3 engine is unplayably slow on Vita.
-# Glk is not very usable on Vita without a keyboard.
 p_master = {
 	"configureargs": [
-		"--disable-all-unstable-engines",
-		"--disable-engines=glk",
-		"--disable-engines=bladerunner",
-		"--disable-engines=stark",
-		"--disable-engines=myst3",
 		"--host=psp2"
 	],
 	"env": scumm_env_psp2,
@@ -911,6 +900,26 @@ p_master = {
 }
 
 p_stable = copy.deepcopy(p_master)
+
+# HACK: To prevent memory-related crash on startup that seems related to the size of the executable
+# file, which grows with number of engines, we need to disable some of the engines...
+# Blade Runner is unplayably slow on the Vita.
+# Stark engine doesn't have a supported renderer on Vita.
+# Myst 3 engine is unplayably slow on Vita.
+# Glk is not very usable on Vita without a keyboard.
+p_master["configureargs"].extend( [
+	"--disable-all-unstable-engines",
+	"--disable-engines=glk",
+	"--disable-engines=bladerunner",
+	"--disable-engines=stark",
+	"--disable-engines=myst3"
+] )
+
+p_stable["configureargs"].extend( [
+	"--disable-all-unstable-engines",
+	"--disable-engines=glk",
+	"--disable-engines=bladerunner"
+] )
 
 scumm_platforms_master["psp2"] = p_master
 scumm_platforms_stable["psp2"] = p_stable


### PR DESCRIPTION
`stable-psp2` builds are currently failing because the `myst3` and `stark` engines aren't in the stable branch: https://buildbot.scummvm.org/builders/stable-psp2/builds/445/steps/configure/logs/stdio