### PR TITLE
CLOUD: Add new storage connection flow

### DIFF
--- a/public/connect-style.css
+++ b/public/connect-style.css
@@ -1,0 +1,108 @@
+.hidden {
+    display: none;
+}
+
+.content {
+    overflow-x: hidden;
+}
+
+.content::before {
+    content: ' ';
+    display: block;
+    opacity: 0;
+    width: 48pt;
+    height: 3pt;
+    background: #0AF;
+    margin-left: -8pt;
+    margin-top: -8pt;
+    margin-bottom: 8pt;    
+    animation: 2s ease-in-out 0s infinite loading;    
+}
+
+#state_connecting.content::before {
+    opacity: 100;
+}
+
+@keyframes loading {
+    from {
+        transform: translateX(-100pt);
+    }
+    to {
+        transform: translateX(calc(500pt + 100pt));
+    }
+}
+
+.content > p {
+    margin-top: 10pt;
+    font-size: 12pt;
+    text-align: left;
+}
+
+.content > p:first-child {
+    margin-top: 6pt;
+    font-size: 18pt;
+    text-align: center;
+}
+
+.content > p:nth-child(2) {
+    margin-top: 10pt;
+    font-size: 12pt;
+    text-align: center;
+}
+
+.content > hr {
+    height: 1px;
+    margin: 18pt 0;
+    border: 0;
+    background: #CCC;
+}
+
+.content > input {
+    font-size: 14pt;
+    border: 1px solid #CCC;
+    padding: 5pt;
+    width: 50%;
+}
+
+.content > button {
+    font-size: 14pt;
+    padding: calc(5pt + 1px);
+    border: 0;
+    background: #821D06;
+    color: #FFF;
+    border-radius: 5px;
+    min-width: 20%;
+}
+
+.content > button:hover {
+    cursor: pointer;
+    background: #B42709;
+}
+
+.content > input,
+.content > button {
+    margin-top: 8pt;
+}
+
+.content > textarea {
+    width: calc(100% - 2*5pt - 2*1px);
+    border: 1px solid #CCC;
+    padding: 5pt;
+    margin-top: 4pt;
+    margin-bottom: 8pt;
+    resize: none;
+}
+
+.content > input:hover,
+.content > textarea:hover {
+    border: 1px solid #AAA;
+}
+
+.content > p > a {
+    color: #821D06;
+}
+
+.content > p > a:hover {
+    color: #E4330B;
+    text-decoration: none;
+}

--- a/public/connect.js
+++ b/public/connect.js
@@ -1,0 +1,52 @@
+window.onload = function () {
+    connect_cloud();
+    document.getElementById("json").value = JSON.stringify(token_json);
+};
+
+function connect_cloud() {
+    display_content("state_connecting");
+
+    var host = document.getElementById("host").value;
+    if (host == "") host = "http://localhost:12345/";
+
+    var url = host + (host.endsWith("/") ? "" : "/") + "connect_cloud";
+    postJsonAndParseJson(
+        url,
+        token_json, 
+        function (json_response) {
+            if (json_response.error) {
+                console.error(json_response);
+                display_content("state_connect_failed");
+            } else {
+                display_content("state_connected");
+            }
+        },
+        function (failed_request) {
+            display_content("state_request_failed");
+        }
+    );
+}
+
+function display_content(id) {
+    var contents = document.querySelectorAll(".content");
+    for (var c of contents) c.classList.add("hidden");
+    document.getElementById(id).classList.remove("hidden");
+}
+
+function postJsonAndParseJson(url, data, callback, error_callback) {
+    var cb = function (responseText) { callback(JSON.parse(responseText)); };
+    var ecb = function (x) { error_callback(x); };
+
+    var x = new XMLHttpRequest();
+    x.open("POST", url, true);
+    x.onreadystatechange = function () {
+        if (x.readyState == XMLHttpRequest.DONE) {
+            if (x.status == 200)
+                cb(x.responseText);
+            else
+                ecb(x);
+        }
+    };
+    x.setRequestHeader('Content-Type', 'application/json');
+    x.send(JSON.stringify(data));
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -88,6 +88,7 @@ return function (App $app) {
                 // If we don't have an authorization code then get one
                 $authUrl = $providerAndScope['provider']->getAuthorizationUrl($providerAndScope['scope']);
                 $_SESSION['oauth2state'] = $providerAndScope['provider']->getState();
+                $_SESSION['newFlow'] = "270";
 
                 return $response->withRedirect($authUrl);
 

--- a/templates/connect.phtml
+++ b/templates/connect.phtml
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+    <head>
+        <title>ScummVM</title>
+        <meta charset="utf-8"/>
+        <link rel="stylesheet" type="text/css" href="/cloud-style.css"/>
+        <link rel="stylesheet" type="text/css" href="/connect-style.css"/>
+        <script>
+            var token_json = {};
+            try {
+                token_json = JSON.parse(atob("<?= $response_base64 ?>"));
+            } catch (e) { console.error(e); };
+        </script>
+        <script src="/connect.js"></script>
+    </head>
+    <body>
+        <div class="container">
+            <div class="header">
+                <img src="https://scummvm.org/images/scummvm_logo.png"/>
+            </div>
+            <div class="content" id="state_connecting">
+                <p>Connecting <?= $provider_name ?>...</p>
+                <p>Please don't close this page yet.</p>
+            </div>
+            <div class="content hidden" id="state_connected">
+                <p>Connected!</p>
+                <p>Now you can close this page and return to ScummVM app.</p>
+            </div>
+            <div class="content hidden" id="state_request_failed">
+                <p>Something went wrong.</p>
+                <p>We couldn't reach your ScummVM app.</p>
+
+                <hr/>
+
+                <p><b>Troubleshooting:</b></p>
+                <p><b>1. Run Local Webserver or specify correct address</b></p>
+                <p>Make sure Local Webserver is running.<br/>If you're using custom port, enter your server's address.<br/>Press "Connect" to try reaching ScummVM again.</p>
+                <input id="host" type="text" placeholder="http://localhost:12345/" value="http://localhost:12345/" />
+                <button onclick="connect_cloud();">Connect</button>
+
+                <br/><br/>
+                <p><b>2. Use Manual mode</b></p>
+                <p>In ScummVM, go back and use Manual mode in connection wizard.<br/>Copy this code in there:</p>
+                <textarea id="json" readonly></textarea>
+            </div>
+            <div class="content hidden" id="state_connect_failed">
+                <p>Something went wrong.</p>
+                <p>We've reached your ScummVM app, but storage wasn't connected.</p>
+
+                <hr/>
+
+                <p><b>Troubleshooting:</b></p>
+                <p><b>1. Update ScummVM</b></p>
+                <p>Make sure to use ScummVM 2.7.1 or newer.<br/><a href="https://www.scummvm.org/downloads/">Go to Downloads</a></p>
+
+                <p style="margin-top: 20pt;"><b>2. Try again</b></p>
+                <p>Try connecting your storage one more time.<br/><a href="https://cloud.scummvm.org/">Go to cloud.scummvm.org</a></p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/templates/connect.phtml
+++ b/templates/connect.phtml
@@ -40,7 +40,7 @@
 
                 <br/><br/>
                 <p><b>2. Use Manual mode</b></p>
-                <p>In ScummVM, go back and use Manual mode in connection wizard.<br/>Copy this code in there:</p>
+                <p>In ScummVM, go back and use Manual mode in connection wizard.<br/>Copy this JSON code in there:</p>
                 <textarea id="json" readonly></textarea>
             </div>
             <div class="content hidden" id="state_connect_failed">

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -13,25 +13,49 @@
             <div class="content">
                 <p>Which cloud do you want to connect?</p>
                 <div class="links-list">
-                    <a href="/dropbox?refresh_token=true" class="link">
+                    <a id="db_link" href="/dropbox?refresh_token=true" class="link">
                         <img src="/images/dropbox.png" />
                         <b>Dropbox</b>
                     </a>
-                    <a href="/onedrive" class="link">
+                    <a id="od_link" href="/onedrive" class="link">
                         <img src="/images/onedrive.png" />
                         <b>OneDrive</b>
                     </a>
-                    <a href="/gdrive" class="link">
+                    <a id="gd_link" href="/gdrive" class="link">
                         <img src="/images/google_drive.png" />
                         <b>Google Drive</b>
                     </a>
-                    <a href="/box" class="link">
+                    <a id="bx_link" href="/box" class="link">
                         <img src="/images/box.png" />
                         <b>Box</b>
                     </a>
                 </div>
+                <p><label for="271_cb"><input type="checkbox" value="off" id="271_cb" onclick="refresh_links();" onchange="refresh_links();" /> ScummVM version 2.7.1 or newer</label></p>
             </div>
             <p>Please note: Clicking on the cloud icons will redirect you to the chosen cloud provider. Please review their privacy policies beforehand.</p>
         </div>
+        <script>
+function refresh_links() {
+    var e = document.getElementById("271_cb");
+    var use271 = (e.checked || e.value == "on");
+    var hrefs = {
+        "db_link": ["/dropbox?refresh_token=true", "/dropbox/271?refresh_token=true"],
+        "od_link": ["/onedrive", "/onedrive/271"],
+        "gd_link": ["/gdrive", "/gdrive/271"],
+        "bx_link": ["/box", "/box/271"],
+    };
+
+    var links = document.querySelectorAll("a.link");
+    for (var link of links) {
+        if (link.id in hrefs) {
+            link.href = hrefs[link.id][use271 ? 1 : 0];
+        }
+    }
+}
+
+window.onload = function () {
+    refresh_links();
+};
+        </script>
     </body>
 </html>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -13,10 +13,6 @@
             <div class="content">
                 <p>Which cloud do you want to connect?</p>
                 <div class="links-list">
-                    <a href="/dropbox" class="link">
-                        <img src="/images/dropbox.png" />
-                        <b>Dropbox (Legacy)<sup class='small'>*</sup></b>
-                    </a>
                     <a href="/dropbox?refresh_token=true" class="link">
                         <img src="/images/dropbox.png" />
                         <b>Dropbox</b>
@@ -35,7 +31,6 @@
                     </a>
                 </div>
             </div>
-            <p>* Dropbox Legacy is used in ScummVM versions up to and including 2.2.1</p>
             <p>Please note: Clicking on the cloud icons will redirect you to the chosen cloud provider. Please review their privacy policies beforehand.</p>
         </div>
     </body>


### PR DESCRIPTION
This change adds a new flow (codename "271") to the cloud.scummvm.org. See the corresponding PR for ScummVM: [#4860](https://github.com/scummvm/scummvm/pull/4860).

![image](https://user-images.githubusercontent.com/1948111/229292477-ccc20206-d402-49b7-97d6-2eae1f6a7b46.png)

New flow doesn't store anything in Redis, and relies on ScummVM's local webserver feature to transfer the data. If this fails, the new page shows some instructions and allows "manual mode" — when user copies the data and pastes it into ScummVM manually.

The old flow is not removed, and is considered default for now. Users could switch to new flow via checkbox on the main cloud.scummvm.org page. Later, the old flow could be removed.