### PR TITLE
PLANET: Use for user-friendly format for dates

### DIFF
--- a/planet-scummvm/planet.scummvm.html.erb
+++ b/planet-scummvm/planet.scummvm.html.erb
@@ -41,7 +41,7 @@
   </h2>
 
   <p class="article-info">
-  <span class="date"><%= item.updated.strftime('%m/%d/%y %H:%M') %></span>
+  <span class="date"><%= item.updated.strftime('%B %d, %Y %H:%M') %></span>
 
   |
 


### PR DESCRIPTION
Since the recent change in planet I have been confused with the dates using american format of month/day/year (`07/01/25` for today's date). Since American may get confused if we switch to day/month/year (`01/07/25`), I am proposing instead to use a more user friendly format (`July 1, 2025`). 

This is for the date at the top of each post:
![image](https://github.com/user-attachments/assets/831b1a7e-409f-4f6c-b3ca-373a476e19b6)
