### PR TITLE
IMAGEDIFF: Add pagination and default to last page

### DIFF
--- a/imagediff/main.py
+++ b/imagediff/main.py
@@ -108,6 +108,21 @@ def get_frame_number(filename):
         
 
 
+def get_pagination_pages(page, total_pages, window=2):
+    """Return list of page numbers with None for ellipsis gaps."""
+    pages = set([1, total_pages])
+    for i in range(max(1, page - window), min(total_pages, page + window) + 1):
+        pages.add(i)
+    result = []
+    prev = None
+    for p in sorted(pages):
+        if prev is not None and p - prev > 1:
+            result.append(None)
+        result.append(p)
+        prev = p
+    return result
+
+
 def get_sorted_builds(target_path, reverse=True):
     """Get sorted list of builds for a target."""
     builds = [b for b in os.listdir(target_path)
@@ -218,18 +233,17 @@ def target_detail(target):
     if not os.path.exists(target_path) or not os.path.isdir(target_path):
         return "Target not found", 404
 
-    # Only get the build list, other time-consuming operations moved to API
-    builds = get_sorted_builds(target_path,reverse=False)
-
-    # Only return the page framework with build list but without table data
-    page = int(request.args.get('page', 1))
+    builds = get_sorted_builds(target_path, reverse=False)
     page_size = 20
+    total_pages = max(1, (len(builds) + page_size - 1) // page_size)
+    page_param = request.args.get('page')
+    page = int(page_param) if page_param is not None else total_pages
+    page = max(1, min(page, total_pages))
     start = (page - 1) * page_size
     end = start + page_size
     paginated_builds = builds[start:end]
-    total_pages = (len(builds) + page_size - 1) // page_size
+    pagination_pages = get_pagination_pages(page, total_pages)
 
-    # Load cache for this target and page
     cache_data = load_target_cache(target, page)
 
     return render_template('target.html',
@@ -238,6 +252,7 @@ def target_detail(target):
         builds=paginated_builds,
         page=page,
         total_pages=total_pages,
+        pagination_pages=pagination_pages,
         cache_data=cache_data)
 
 

--- a/imagediff/static/css/style.css
+++ b/imagediff/static/css/style.css
@@ -129,3 +129,66 @@ a:hover {
         max-height: 300px;
     }
 }
+
+.pagination-container {
+    margin-top: 12px;
+}
+
+.pagination {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.page-btn {
+    display: inline-block;
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    color: #337ab7;
+    background: #fff;
+    cursor: pointer;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.page-btn:hover {
+    background: #e8f0fe;
+    text-decoration: none;
+}
+
+.page-btn.current {
+    background: #337ab7;
+    color: #fff;
+    border-color: #337ab7;
+    font-weight: bold;
+}
+
+.page-btn.disabled {
+    color: #aaa;
+    border-color: #eee;
+    cursor: default;
+    pointer-events: none;
+}
+
+.page-ellipsis {
+    padding: 4px 4px;
+    color: #666;
+}
+
+.page-jump-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+}
+
+.page-jump-input {
+    width: 60px;
+    padding: 4px 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+}

--- a/imagediff/templates/target.html
+++ b/imagediff/templates/target.html
@@ -104,25 +104,37 @@
         <div class="pagination-container">
     {% if total_pages > 1 %}
         <div class="pagination">
-
             {% if page > 1 %}
-                <a class="page-btn"
-                   href="{{ url_for('target_detail', target=target) }}?page={{ page - 1 }}">
-                    ⬅ Previous
-                </a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page=1">|&lt;</a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ page - 1 }}">&lt;</a>
+            {% else %}
+                <span class="page-btn disabled">|&lt;</span>
+                <span class="page-btn disabled">&lt;</span>
             {% endif %}
 
-            <span class="page-info">
-                Page {{ page }} of {{ total_pages }}
-            </span>
+            {% for p in pagination_pages %}
+                {% if p is none %}
+                    <span class="page-ellipsis">…</span>
+                {% elif p == page %}
+                    <span class="page-btn current">{{ p }}</span>
+                {% else %}
+                    <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ p }}">{{ p }}</a>
+                {% endif %}
+            {% endfor %}
 
             {% if page < total_pages %}
-                <a class="page-btn"
-                   href="{{ url_for('target_detail', target=target) }}?page={{ page + 1 }}">
-                    Next ➡
-                </a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ page + 1 }}">&gt;</a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ total_pages }}">&gt;|</a>
+            {% else %}
+                <span class="page-btn disabled">&gt;</span>
+                <span class="page-btn disabled">&gt;|</span>
             {% endif %}
 
+            <form method="get" class="page-jump-form">
+                <input type="number" name="page" min="1" max="{{ total_pages }}"
+                       placeholder="{{ page }}" class="page-jump-input">
+                <button type="submit" class="page-btn">Go</button>
+            </form>
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
- Target detail page opens on the last page by default, so the most recent builds are shown
- Replace previous/next buttons with pagination controls: |< < … 100 101 102 103 … > >|,  [textbox] [GO] to jump to any page
- Add CSS styles for pagination buttons, current page highlight, disabled states, ellipsis