### PR TITLE
IMAGEDIFF: Replace image comparison with file check

### DIFF
--- a/imagediff/imagediff.py
+++ b/imagediff/imagediff.py
@@ -67,72 +67,23 @@ def find_baseline_build(screenshots_dir, target, current_build):
 
 def movie_diff(src_build, cmp_build, target, movie, screenshots_dir=None):
     """
-    Compare all frames of a movie between two builds and determine if there are any differences.
+    Determine if a movie differs between two builds by checking file presence.
 
-    Args:
-        src_build (str): The source build name
-        cmp_build (str): The comparison build name
-        target (str): The target name
-        movie (str): The movie name
-        screenshots_dir (str): Override for SCREENSHOTS_DIR from config
-
-    Returns:
-        bool: True if any frame has differences, False otherwise
+    The Director engine only saves a screenshot when it detects a change vs the
+    previous build (using pixel comparison with a threshold). So if a frame file
+    exists in a build, the engine already confirmed it differs. No PIL comparison
+    needed here, file presence IS the diff signal.
     """
     screenshots_dir = screenshots_dir or SCREENSHOTS_DIR
     src_build_path = os.path.join(screenshots_dir, target, src_build)
     cmp_build_path = os.path.join(screenshots_dir, target, cmp_build)
 
-    # Ensure both build paths exist
     if not os.path.exists(src_build_path) or not os.path.exists(cmp_build_path):
         return False
 
-    # Get all frames for this movie in both builds
-    src_frames = [f for f in os.listdir(src_build_path)
-                  if os.path.isfile(os.path.join(src_build_path, f)) and f.startswith(f"{movie}-")]
+    cmp_frames = {f for f in os.listdir(cmp_build_path) if f.startswith(f"{movie}-")}
 
-    cmp_frames = [f for f in os.listdir(cmp_build_path)
-                  if os.path.isfile(os.path.join(cmp_build_path, f)) and f.startswith(f"{movie}-")]
+    # The engine only saves a screenshot file when it detects a change vs the previous build.
+    # So any file in cmp_build means cmp_build differs from src_build.
+    return len(cmp_frames) > 0
 
-    # If frame counts differ, there's definitely a difference
-    if len(src_frames) != len(cmp_frames):
-        return True
-
-    # Helper function to extract frame number from filename
-    def get_frame_number(filename):
-        parts = filename.split('-')
-        if len(parts) > 1:
-            try:
-                return int(parts[1].split('.')[0])
-            except ValueError:
-                return 0
-        return 0
-
-    src_frame_map = {get_frame_number(f): f for f in src_frames}
-    cmp_frame_map = {get_frame_number(f): f for f in cmp_frames}
-
-    all_frame_numbers = sorted(set(list(src_frame_map.keys()) + list(cmp_frame_map.keys())))
-
-    if set(src_frame_map.keys()) != set(cmp_frame_map.keys()):
-        return True
-
-    for frame_num in all_frame_numbers:
-        src_frame = src_frame_map.get(frame_num)
-        cmp_frame = cmp_frame_map.get(frame_num)
-
-        if src_frame and cmp_frame:
-            src_img_path = os.path.join(src_build_path, src_frame)
-            cmp_img_path = os.path.join(cmp_build_path, cmp_frame)
-
-            try:
-                diff_result = image_diff(src_img_path, cmp_img_path)
-
-                if diff_result.get('has_diff', False):
-                    return True
-            except Exception as e:
-                print(f"Error comparing frames {src_frame} and {cmp_frame}: {e}")
-                return True
-        else:
-            return True
-
-    return False

--- a/imagediff/main.py
+++ b/imagediff/main.py
@@ -328,24 +328,11 @@ def target_data_api(target):
                 movie_reference_builds[movie][current_build] = reference_data
 
     def get_image_diff(current_build, prev_build, movie, frame):
-        cache_key = make_cache_key(target, current_build, prev_build, movie, frame)
-        image_diff_cache = load_frame_cache(target)
-        if cache_key in image_diff_cache:
-            return image_diff_cache[cache_key]
-
         current_frame_path = os.path.join(target_path, current_build, f"{movie}-{frame}.png")
         prev_frame_path = os.path.join(target_path, prev_build, f"{movie}-{frame}.png")
-
-        if os.path.exists(current_frame_path) and os.path.exists(prev_frame_path):
-            try:
-                image_diff_cache[cache_key] = image_diff(current_frame_path, prev_frame_path)
-            except Exception as e:
-                print(f"Error comparing frames {movie}-{frame}: {e}")
-                image_diff_cache[cache_key] = {'has_diff': True}
-        else:
-            image_diff_cache[cache_key] = {'has_diff': True}
-        save_frame_cache(target, image_diff_cache)
-        return image_diff_cache[cache_key]
+        # File presence is the diff signal, engine only saves when it detects a change
+        has_diff = os.path.exists(current_frame_path) and os.path.exists(prev_frame_path)
+        return {'has_diff': has_diff}
 
     # Modified movie difference function to only compare specified frames
     def get_movie_diff_for_frames(current_build, reference_build, target, movie, frames_to_compare):
@@ -468,7 +455,8 @@ def target_data_api(target):
                             'is_partial': True
                         })
                     else:
-                        has_diff = movie_diff(current_build, prev_build, target, movie)
+                        has_diff = get_movie_diff_for_frames(
+                            current_build, prev_build, target, movie, list(common_frames))
 
                         continuous_bars[movie].append({
                             'build': current_build,

--- a/imagediff/main.py
+++ b/imagediff/main.py
@@ -108,6 +108,21 @@ def get_frame_number(filename):
         
 
 
+def get_pagination_pages(page, total_pages, window=2):
+    """Return list of page numbers with None for ellipsis gaps."""
+    pages = set([1, total_pages])
+    for i in range(max(1, page - window), min(total_pages, page + window) + 1):
+        pages.add(i)
+    result = []
+    prev = None
+    for p in sorted(pages):
+        if prev is not None and p - prev > 1:
+            result.append(None)
+        result.append(p)
+        prev = p
+    return result
+
+
 def get_sorted_builds(target_path, reverse=True):
     """Get sorted list of builds for a target."""
     builds = [b for b in os.listdir(target_path)
@@ -218,18 +233,17 @@ def target_detail(target):
     if not os.path.exists(target_path) or not os.path.isdir(target_path):
         return "Target not found", 404
 
-    # Only get the build list, other time-consuming operations moved to API
-    builds = get_sorted_builds(target_path,reverse=False)
-
-    # Only return the page framework with build list but without table data
-    page = int(request.args.get('page', 1))
+    builds = get_sorted_builds(target_path, reverse=False)
     page_size = 20
+    total_pages = max(1, (len(builds) + page_size - 1) // page_size)
+    page_param = request.args.get('page')
+    page = int(page_param) if page_param is not None else total_pages
+    page = max(1, min(page, total_pages))
     start = (page - 1) * page_size
     end = start + page_size
     paginated_builds = builds[start:end]
-    total_pages = (len(builds) + page_size - 1) // page_size
+    pagination_pages = get_pagination_pages(page, total_pages)
 
-    # Load cache for this target and page
     cache_data = load_target_cache(target, page)
 
     return render_template('target.html',
@@ -238,6 +252,7 @@ def target_detail(target):
         builds=paginated_builds,
         page=page,
         total_pages=total_pages,
+        pagination_pages=pagination_pages,
         cache_data=cache_data)
 
 

--- a/imagediff/static/css/style.css
+++ b/imagediff/static/css/style.css
@@ -129,3 +129,66 @@ a:hover {
         max-height: 300px;
     }
 }
+
+.pagination-container {
+    margin-top: 12px;
+}
+
+.pagination {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+.page-btn {
+    display: inline-block;
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    color: #337ab7;
+    background: #fff;
+    cursor: pointer;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.page-btn:hover {
+    background: #e8f0fe;
+    text-decoration: none;
+}
+
+.page-btn.current {
+    background: #337ab7;
+    color: #fff;
+    border-color: #337ab7;
+    font-weight: bold;
+}
+
+.page-btn.disabled {
+    color: #aaa;
+    border-color: #eee;
+    cursor: default;
+    pointer-events: none;
+}
+
+.page-ellipsis {
+    padding: 4px 4px;
+    color: #666;
+}
+
+.page-jump-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+}
+
+.page-jump-input {
+    width: 60px;
+    padding: 4px 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+}

--- a/imagediff/templates/target.html
+++ b/imagediff/templates/target.html
@@ -104,25 +104,37 @@
         <div class="pagination-container">
     {% if total_pages > 1 %}
         <div class="pagination">
-
             {% if page > 1 %}
-                <a class="page-btn"
-                   href="{{ url_for('target_detail', target=target) }}?page={{ page - 1 }}">
-                    ⬅ Previous
-                </a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page=1">|&lt;</a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ page - 1 }}">&lt;</a>
+            {% else %}
+                <span class="page-btn disabled">|&lt;</span>
+                <span class="page-btn disabled">&lt;</span>
             {% endif %}
 
-            <span class="page-info">
-                Page {{ page }} of {{ total_pages }}
-            </span>
+            {% for p in pagination_pages %}
+                {% if p is none %}
+                    <span class="page-ellipsis">…</span>
+                {% elif p == page %}
+                    <span class="page-btn current">{{ p }}</span>
+                {% else %}
+                    <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ p }}">{{ p }}</a>
+                {% endif %}
+            {% endfor %}
 
             {% if page < total_pages %}
-                <a class="page-btn"
-                   href="{{ url_for('target_detail', target=target) }}?page={{ page + 1 }}">
-                    Next ➡
-                </a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ page + 1 }}">&gt;</a>
+                <a class="page-btn" href="{{ url_for('target_detail', target=target) }}?page={{ total_pages }}">&gt;|</a>
+            {% else %}
+                <span class="page-btn disabled">&gt;</span>
+                <span class="page-btn disabled">&gt;|</span>
             {% endif %}
 
+            <form method="get" class="page-jump-form">
+                <input type="number" name="page" min="1" max="{{ total_pages }}"
+                       placeholder="{{ page }}" class="page-jump-input">
+                <button type="submit" class="page-btn">Go</button>
+            </form>
         </div>
     {% endif %}
 </div>


### PR DESCRIPTION
The logic for Image comparison I had written earlier was fundamentally wrong
- replace image_diff() calls in movie_diff() and get_image_diff() with file existence checks.
- remove json comparison per each frame, it's loaded once at the startand saved once at the end.