### PR TITLE
IMAGEDIFF: Fix imports after merging imagediff.py into main.py

### DIFF
--- a/director/screenshot_diff.py
+++ b/director/screenshot_diff.py
@@ -1,6 +1,6 @@
 """Screenshot comparison for Director buildbot tests.
 
-Uses comparison logic from imagediff/imagediff.py. Invoked on the worker by
+Uses comparison logic from imagediff/main.py. Invoked on the worker by
 ScreenshotDiffStep after ScummVMTest when screenshot debugflags are enabled.
 """
 
@@ -19,7 +19,7 @@ EXIT_ERROR = 3
 
 _seen_prefixes_name = ".screenshot_prefixes_seen"
 
-from imagediff import imagediff as _imagediff  # imagediff/imagediff.py
+from imagediff import main as _imagediff  # imagediff/main.py
 
 
 def _seen_prefixes_path(screenshots_dir: str, target: str, build: str) -> str:

--- a/imagediff/main.py
+++ b/imagediff/main.py
@@ -4,15 +4,15 @@ import sys
 import base64
 from io import BytesIO
 
-from PIL import Image, ImageChops
-
-from config import SCREENSHOTS_DIR
-
-from flask import Flask, render_template, jsonify, url_for, send_from_directory, request
-
+# config.py lives next to this file; make it importable no matter where we
+# are imported from (buildbot master, worker step, or standalone).
 _imagediff_dir = os.path.dirname(__file__)
 if _imagediff_dir not in sys.path:
     sys.path.insert(0, _imagediff_dir)
+
+from PIL import Image, ImageChops
+
+from flask import Flask, render_template, jsonify, url_for, send_from_directory, request
 
 from config import CACHE_DIR, SCREENSHOTS_DIR
 
@@ -118,24 +118,6 @@ def unescape_string(s: str) -> str:
             orig_name += hi
         hi = next(s_iter, None)
     return orig_name
-
-def decode_string2(orig: str) -> str:
-    """
-    Decode punyencoded strings
-    """
-    print("Decoding string:", orig)
-    if not orig.startswith("xn--"):
-        return orig
-
-    print("called for xn")
-    i = len(orig) - 1
-    while i >= 0 and orig[i] == "-":
-        i -= 1
-
-    orig = orig[:i+1]
-
-    st = orig[4:].encode("ascii").decode("punycode")
-    return unescape_string(st)
 
 def decode_string(orig: str) -> str:
     """
@@ -621,7 +603,7 @@ def target_data_api(target):
         'target': target,
         'builds': display_builds,
         'movies': movies,
-        'display_movies': [print(f"DEBUG movie: {repr(m)}") or decode_string(m) for m in movies],
+        'display_movies': [decode_string(m) for m in movies],
         'continuous_bars': continuous_bars,
         'urls': urls
     }

--- a/imagediff/templates/target.html
+++ b/imagediff/templates/target.html
@@ -155,17 +155,12 @@
         // Show loading animation
         loadingOverlay.classList.remove('hidden');
 
-        // Build API URL
+        // Build API URL. The app may be mounted under a URL prefix (buildbot
+        // wsgi_dashboards), so derive the base path from the current location
+        // instead of using url_for.
         const target = '{{ target }}';
-	// const apiUrl = `{{ url_for('target_data_api', target=target) }}?page={{ page }}`;
-	// const apiUrl = `{{ url_for('target_data_api', target=target) }}?page={{ page }}`;
-	const basePath = window.location.pathname.replace(/\/target\/[^/]*$/, '');
+        const basePath = window.location.pathname.replace(/\/target\/[^/]*$/, '');
         const apiUrl = `${basePath}/api/target_data/${encodeURIComponent(target)}?page={{ page }}`;
-	console.log('pathname:', window.location.pathname, 'basePath:', basePath);
-
-
-
-
 
         // Start timestamp for calculating loading time
         const startTime = new Date().getTime();


### PR DESCRIPTION
- main.py: run the sys.path bootstrap before importing config, drop the duplicate import. master.py could not load the dashboard from a fresh start (ModuleNotFoundError: config)
- screenshot_diff.py: import from imagediff.main; imagediff/imagediff.py no longer exists, so every ScreenshotDiffStep failed silently
- Remove leftover debug prints, dead decode_string2, and commented-out code in target.html